### PR TITLE
Added a job board for frontend remote jobs

### DIFF
--- a/Frontend-Development/Job-Boards/Readme.md
+++ b/Frontend-Development/Job-Boards/Readme.md
@@ -3,6 +3,7 @@
 - [Frontend Engineer](https://angel.co/role/r/frontend-engineer) - Angel.co
 - [Frontend Developer](https://www.glassdoor.co.in/Job/remote-front-end-developer-jobs-SRCH_IL.0,6_IS12638_KO7,26.htm?suggestCount=0&suggestChosen=false&clickSource=searchBtn&typedKeyword=&typedLocation=remote&context=Jobs&dropdown=0) - Glassdoor
 - [JavaScript Jobs](https://javascriptjob.xyz)
+- [Job Board Search](https://jobboardsearch.com/entry-level+frontend-jobs-only+remote-jobs?remote_data=true) - Frontend remote jobs
 - [LinkedIn Job Board](https://www.linkedin.com/jobs/search/?geoId=92000000&keywords=frontend%20developer&location=Worldwide)
 - [React Jobs](https://reactjsjob.com)
 - [Web Developer (Frontend)](https://in.indeed.com/jobs?q=frontend&l=remote&vjk=f5117464e8d68692) - Indeed.com


### PR DESCRIPTION
I've added a job board search website for frontend remote jobs in the /Frontend-Development/Job-Boards folder while keeping the alphabetical order of the folder unchanged. This is in reference to issue #77  which I've closed by mistake.